### PR TITLE
add support for emerge and dpkg

### DIFF
--- a/functions.c
+++ b/functions.c
@@ -76,7 +76,7 @@ const char* get_uptime() {
 	return buffer;
 }
 
-int get_installed_packages_pacman() {
+static int get_installed_packages_pacman() {
 	int package_count = 0;
 	DIR* dir = opendir("/var/lib/pacman/local");
 	if (dir) {
@@ -91,7 +91,7 @@ int get_installed_packages_pacman() {
 	return package_count;
 }
 
-int get_installed_packages_emerge() {
+static int get_installed_packages_emerge() {
 	int package_count = 0;
 	DIR* dir = opendir("/var/db/pkg");
 	if (!dir)
@@ -121,7 +121,7 @@ int get_installed_packages_emerge() {
 	return package_count;
 }
 
-int get_installed_packages_dpkg() {
+static int get_installed_packages_dpkg() {
 	int package_count = 0;
 	FILE* file = fopen("/var/lib/dpkg/status", "r");
 	if (!file)
@@ -135,6 +135,12 @@ int get_installed_packages_dpkg() {
 
 	fclose(file);
 	return package_count;
+}
+
+int get_installed_packages() {
+	return   get_installed_packages_pacman()
+	       + get_installed_packages_emerge()
+	       + get_installed_packages_dpkg();
 }
 
 const char* get_memory_usage() {

--- a/main.c
+++ b/main.c
@@ -1,13 +1,27 @@
 #include "main.h"
 
 void setup_details() {
-	snprintf(details[DETAIL_OFFSET + 0], BUFFER_SIZE, "%s@%s", get_username(), get_hostname());
-	snprintf(details[DETAIL_OFFSET + 1], BUFFER_SIZE, "Distro - %s", get_distribution());
-	snprintf(details[DETAIL_OFFSET + 2], BUFFER_SIZE, "System - %s", get_machine_name());
-	snprintf(details[DETAIL_OFFSET + 3], BUFFER_SIZE, "Kernel - %s", get_kernel());
-	snprintf(details[DETAIL_OFFSET + 4], BUFFER_SIZE, "Uptime - %s", get_uptime());
-	snprintf(details[DETAIL_OFFSET + 5], BUFFER_SIZE, "Pacman - %d", get_installed_packages());
-	snprintf(details[DETAIL_OFFSET + 6], BUFFER_SIZE, "Memory - %s", get_memory_usage());
+	int row = 0;
+	int cnt;
+
+#define PRINT(...) if (DETAIL_OFFSET + row < LOGO_HEIGHT) snprintf(details[DETAIL_OFFSET + row++], BUFFER_SIZE, __VA_ARGS__)
+
+	PRINT("%s@%s", get_username(), get_hostname());
+	PRINT("Distro - %s", get_distribution());
+	PRINT("System - %s", get_machine_name());
+	PRINT("Kernel - %s", get_kernel());
+	PRINT("Uptime - %s", get_uptime());
+
+	if ((cnt = get_installed_packages_pacman()))
+		PRINT("Pacman - %d", cnt);
+	if ((cnt = get_installed_packages_emerge()))
+		PRINT("Emerge - %d", cnt);
+	if ((cnt = get_installed_packages_dpkg()))
+		PRINT("Dpkg   - %d", cnt);
+
+	PRINT("Memory - %s", get_memory_usage());
+
+#undef PRINT
 }
 
 int main(int argc, char *argv[]) {

--- a/main.c
+++ b/main.c
@@ -1,27 +1,13 @@
 #include "main.h"
 
 void setup_details() {
-	int row = 0;
-	int cnt;
-
-#define PRINT(...) if (DETAIL_OFFSET + row < LOGO_HEIGHT) snprintf(details[DETAIL_OFFSET + row++], BUFFER_SIZE, __VA_ARGS__)
-
-	PRINT("%s@%s", get_username(), get_hostname());
-	PRINT("Distro - %s", get_distribution());
-	PRINT("System - %s", get_machine_name());
-	PRINT("Kernel - %s", get_kernel());
-	PRINT("Uptime - %s", get_uptime());
-
-	if ((cnt = get_installed_packages_pacman()))
-		PRINT("Pacman - %d", cnt);
-	if ((cnt = get_installed_packages_emerge()))
-		PRINT("Emerge - %d", cnt);
-	if ((cnt = get_installed_packages_dpkg()))
-		PRINT("Dpkg   - %d", cnt);
-
-	PRINT("Memory - %s", get_memory_usage());
-
-#undef PRINT
+	snprintf(details[DETAIL_OFFSET + 0], BUFFER_SIZE, "%s@%s", get_username(), get_hostname());
+	snprintf(details[DETAIL_OFFSET + 1], BUFFER_SIZE, "Distro - %s", get_distribution());
+	snprintf(details[DETAIL_OFFSET + 2], BUFFER_SIZE, "System - %s", get_machine_name());
+	snprintf(details[DETAIL_OFFSET + 3], BUFFER_SIZE, "Kernel - %s", get_kernel());
+	snprintf(details[DETAIL_OFFSET + 4], BUFFER_SIZE, "Uptime - %s", get_uptime());
+	snprintf(details[DETAIL_OFFSET + 5], BUFFER_SIZE, "PkgCnt - %d", get_installed_packages());
+	snprintf(details[DETAIL_OFFSET + 6], BUFFER_SIZE, "Memory - %s", get_memory_usage());
 }
 
 int main(int argc, char *argv[]) {

--- a/main.h
+++ b/main.h
@@ -15,5 +15,7 @@ const char* get_distribution();
 const char* get_machine_name();
 const char* get_kernel();
 const char* get_uptime();
-int get_installed_packages();
+int get_installed_packages_pacman();
+int get_installed_packages_emerge();
+int get_installed_packages_dpkg();
 const char* get_memory_usage();

--- a/main.h
+++ b/main.h
@@ -15,7 +15,5 @@ const char* get_distribution();
 const char* get_machine_name();
 const char* get_kernel();
 const char* get_uptime();
-int get_installed_packages_pacman();
-int get_installed_packages_emerge();
-int get_installed_packages_dpkg();
+int get_installed_packages();
 const char* get_memory_usage();


### PR DESCRIPTION
This adds support for emerge (used on Gentoo) and for dpkg (used on Debian-based distros) for installed package count. I don't currently have other distros to add their package managers.